### PR TITLE
Fix from_slot framing: reconnect-recovery, not historical backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,23 +211,24 @@ def create_subscription_request():
 - `failed = False`: exclude failed transactions to reduce noise.
 - `PROCESSED` commitment: get updates as soon as transactions are processed (fastest possible).
 
-#### Using `from_slot` for historical data
+#### Using `from_slot` to recover missed slots
 
-The `from_slot` parameter allows you to replay blockchain data from a specific historical slot:
+The `from_slot` parameter replays recent slots from a server-side ring buffer, so a client that briefly disconnects can reconnect and catch up without missing events. It is a reconnection-recovery mechanism, not a historical backfill:
 
 ```python
 request = geyser_pb2.SubscribeRequest(
     slots={"filter": geyser_pb2.SubscribeRequestFilterSlots()},
     commitment=geyser_pb2.CommitmentLevel.PROCESSED,
-    from_slot=362520000  # Start from this historical slot
+    from_slot=current_slot - 100  # replay the last ~100 slots; older than the buffer errors
 )
 ```
 
 What is `from_slot`?
-- Starts streaming from a specific slot instead of the current slot
-- Useful for replaying missed events and backfilling after short downtime
-- Limited by the data retention (usually a few minutes)
-- If the requested slot is too old, you'll get an error with the oldest available slot
+- Starts streaming from a recent past slot instead of the current slot
+- Useful for recovering events missed during a short disconnect
+- Limited by a small server-side buffer (roughly the last ~100 slots, about a minute, on shared nodes; dedicated nodes can be configured larger)
+- If the requested slot is older than the buffer, you'll get an `OUT_OF_RANGE` error with the oldest available slot
+- For arbitrary historical data, use JSON-RPC (`getBlock`, `getSignaturesForAddress`, `getTransaction`) instead
 
 ### Step 7: Instruction data decoding
 
@@ -349,7 +350,7 @@ Here are short summaries of each learning example file, from basic to advanced, 
 ### Other subscriptions
 
 - **`slots_subscription.py`**: this example shows how to subscribe to slot updates, giving you a real-time feed of when new slots are processed by the validator.
-- **`historical_replay_with_from_slot.py`**: demonstrates using the `from_slot` parameter to replay historical blockchain data from a specific slot instead of starting from the current slot.
+- **`recover_missed_slots_with_from_slot.py`**: demonstrates using the `from_slot` parameter to recover slots missed during a brief disconnect by replaying from a recent past slot. It is a reconnection-recovery mechanism, not a historical backfill — for older data, use JSON-RPC.
 - **`blocks_subscription.py`**: this script demonstrates how to subscribe to entire blocks that contain transactions interacting with a specific account.
 - **`blocks_meta_subscription.py`**: this example shows how to subscribe to just the metadata of blocks, which is a lightweight way to track block production.
 - **`entries_subscription.py`**: this script demonstrates how to subscribe to ledger entries, which provides a low-level stream of the changes being written to the Solana ledger.

--- a/learning-examples/recover_missed_slots_with_from_slot.py
+++ b/learning-examples/recover_missed_slots_with_from_slot.py
@@ -16,16 +16,21 @@ GEYSER_API_TOKEN = os.getenv("GEYSER_API_TOKEN")
 
 async def main():
     """
-    Demonstrates using from_slot parameter for historical data replay.
-    
-    The from_slot parameter allows you to start streaming from a specific slot
-    instead of the current slot. This is useful for:
-    - Replaying historical data
-    - Backfilling missed events
-    - Testing with past blockchain data
-    - Analyzing historical patterns
-    
-    Note: Typically only recent slots (within a few minutes/hours) are available.
+    Demonstrates using the from_slot parameter to recover slots missed during a
+    brief disconnect.
+
+    from_slot starts the stream from a past slot instead of the current slot, so
+    a client that briefly drops its connection can reconnect and replay the gap
+    without missing events.
+
+    It is a reconnection-recovery mechanism, NOT a historical backfill. The
+    server keeps only a small ring buffer of recent slots (roughly the last ~100
+    slots, about a minute, on shared nodes). Requesting a from_slot older than
+    the buffer returns OUT_OF_RANGE with the oldest available slot. Dedicated
+    nodes can be configured with a larger buffer.
+
+    For arbitrary historical data, use the JSON-RPC methods (getBlock,
+    getSignaturesForAddress, getTransaction) instead of from_slot.
     """
     async with grpc.aio.secure_channel(
         GEYSER_ENDPOINT,
@@ -40,17 +45,17 @@ async def main():
     ) as channel:
         stub = geyser_pb2_grpc.GeyserStub(channel)
 
-        # First, try to get a current slot by subscribing briefly
+        # First, get the current slot by subscribing briefly
         print("📍 Getting current network slot...")
         current_slot = None
-        
+
         try:
             # Try Ping first
             ping_request = geyser_pb2.PingRequest()
             ping_response = await stub.Ping(ping_request)
             current_slot = ping_response.slot
             print(f"   Current slot from Ping: {current_slot}")
-        except:
+        except Exception:
             # If Ping doesn't work, get it from a brief subscription
             temp_request = geyser_pb2.SubscribeRequest(
                 slots={"temp": geyser_pb2.SubscribeRequestFilterSlots()},
@@ -61,47 +66,48 @@ async def main():
                     current_slot = response.slot.slot
                     print(f"   Current slot from stream: {current_slot}")
                     break
-        
+
         if not current_slot:
             print("   ⚠️  Could not get current slot")
             return
 
-        # Calculate a starting point - use a safe value within retention window
-        # Each slot is ~400ms, so 100 slots = ~40 seconds
-        slots_back = 100  # Conservative value that should always work
+        # Start within the replay buffer. The buffer is small (~100 slots on
+        # shared nodes), so use a conservative offset. Older than the buffer
+        # returns OUT_OF_RANGE — for real history use JSON-RPC, not from_slot.
+        slots_back = 100  # conservative; within the ~100-slot shared-node buffer
         from_slot = current_slot - slots_back
-        
+
         print(f"⏰ Replaying from slot {from_slot} ({slots_back} slots back)")
-        print(f"   This represents approximately {slots_back * 0.4 / 60:.1f} minutes of history")
+        print(f"   That's roughly {slots_back * 0.4 / 60:.1f} minutes of recent slots")
         print("---")
 
-        # Create subscription with from_slot parameter
+        # Create subscription with from_slot to replay the recent gap
         request = geyser_pb2.SubscribeRequest(
             slots={
-                "historical": geyser_pb2.SubscribeRequestFilterSlots(
+                "recover": geyser_pb2.SubscribeRequestFilterSlots(
                     filter_by_commitment=True,
                 )
             },
             commitment=geyser_pb2.CommitmentLevel.PROCESSED,
-            from_slot=from_slot  # Start from historical slot
+            from_slot=from_slot,  # replay from this recent slot
         )
 
-        print("🚀 Starting historical replay...")
-        print("📡 Streaming slots from the past to present...")
+        print("🚀 Replaying recent slots from the buffer...")
+        print("📡 Catching up from the past slot to the current tip...")
         print("---")
 
         slot_count = 0
         first_slot = None
-        
+
         try:
             async for response in stub.Subscribe(iter([request])):
                 if response.slot:
                     slot_count += 1
-                    
+
                     if first_slot is None:
                         first_slot = response.slot.slot
-                        print(f"✅ First historical slot received: {first_slot}")
-                    
+                        print(f"✅ First replayed slot received: {first_slot}")
+
                     # Show progress every 100 slots
                     if slot_count % 100 == 0:
                         current = response.slot.slot
@@ -110,26 +116,28 @@ async def main():
                         print(f"   Current slot: {current}")
                         print(f"   Catching up: {progress:.1f}% complete")
                         print("---")
-                    
+
                     # Stop after catching up to near-current
                     if response.slot.slot >= current_slot - 10:
-                        print(f"🎉 Caught up to current slot!")
-                        print(f"   Processed {slot_count} historical slots")
+                        print("🎉 Caught up to current slot!")
+                        print(f"   Replayed {slot_count} slots")
                         print(f"   From: {first_slot}")
                         print(f"   To: {response.slot.slot}")
                         break
-                        
+
         except grpc.RpcError as e:
             if "not available" in str(e.details()):
-                # Extract the oldest available slot from error message
+                # The requested slot fell outside the replay buffer
                 import re
                 match = re.search(r"last available: (\d+)", str(e.details()))
                 if match:
                     oldest = int(match.group(1))
-                    print(f"❌ Requested slot {from_slot} is too old")
+                    depth = current_slot - oldest
+                    print(f"❌ Requested slot {from_slot} is outside the replay buffer")
                     print(f"   Oldest available slot: {oldest}")
-                    print(f"   That's {(current_slot - oldest) * 0.4 / 3600:.1f} hours of history")
-                    print("\n💡 Tip: Try using a more recent from_slot value")
+                    print(f"   Buffer depth: ~{depth} slots (~{depth * 0.4 / 60:.1f} minutes)")
+                    print("\n💡 from_slot only covers the recent buffer. For older data,")
+                    print("   use JSON-RPC (getBlock / getSignaturesForAddress / getTransaction).")
             else:
                 print(f"❌ Error: {e.code()} - {e.details()}")
 
@@ -138,6 +146,6 @@ if __name__ == "__main__":
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
-        print("\n🛑 Historical replay stopped")
+        print("\n🛑 Replay stopped")
     except Exception as e:
         print(f"❌ Error: {e}")


### PR DESCRIPTION
## What

`from_slot` was documented and named as "historical replay," but it only replays a small ring buffer of recent slots (~100 slots / ~1 minute on shared nodes), not arbitrary history.

- Rename `historical_replay_with_from_slot.py` → `recover_missed_slots_with_from_slot.py`; reframe the docstring and output as reconnection recovery, and point to JSON-RPC for real history.
- README: fix the heading and intro, replace the broken snippet (`from_slot=362520000`, a months-old slot that always returns `OUT_OF_RANGE`) with `current_slot - 100` plus a buffer note, correct the "What is `from_slot`?" bullets, and update the example list.

## Why

The "historical replay / backfill from any slot" framing overstates the feature, and the hardcoded example never runs. `from_slot` is for catching up after a brief disconnect. For arbitrary historical data, use JSON-RPC (`getBlock` / `getSignaturesForAddress` / `getTransaction`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `from_slot` parameter usage for recovering missed slots after reconnection.
  * Added guidance on server-side replay buffer limitations and error handling for out-of-range requests.
  * Provided updated example demonstrating reconnection-recovery workflow with proper slot offset calculation and catch-up detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->